### PR TITLE
Add GameMaker-Save (NiZaMinius) to Native Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This includes data structures and file formats that do not fit into a more speci
 
 These work on specific platform(s) and enable the games to do something that would be impossible, impractical, or inefficient to do in GML alone. Native extensions related to a specific task (e.g. input handling) can be found in those sections.
 
+- [GameMaker-Save](https://github.com/NiZaMinius/GameMaker-Save) - High‑performance, secure save system for GameMaker via a Rust cdylib (XChaCha20‑Poly1305). Supports GMS 2.3+
 - [GM-ExtensionGenerator](https://github.com/YoYoGames/GM-ExtensionGenerator) - Official, schema-driven code generator for native extensions.
 - [zlib functions](https://yellowafterlife.itch.io/gamemaker-zlib) - Simple compression/decompression functions.
 - [Window Taskbar](https://yellowafterlife.itch.io/gamemaker-window-taskbar) - Windows only. Flash the game window border and/or its taskbar button.


### PR DESCRIPTION
Adds GameMaker-Save native extension to provide fast, secure saves for GameMaker.

- What it is: High-performance save system implemented as a Rust cdylib with a thin GML wrapper. Uses XChaCha20-Poly1305 for authenticated encryption.
- Why add it: Secure, adds save protection, easy-to-use saving for GMS projects that need confidentiality/integrity and good performance.
- Key features:
  - Rust cdylib (safe, fast) + GML bindings
  - XChaCha20‑Poly1305 authenticated encryption
  - Ready-to-import .yymps package for easy installation
  - Build instructions for Windows, macOS and Linux (desktop)
  - Usage examples in the repo README
- Compatibility: Targets GameMaker Studio 2.3+ (GML 2.3 syntax)
- License: MIT / Apache-2.0 (see LICENSE in the repository)
- Repo: https://github.com/NiZaMinius/GameMaker-Save